### PR TITLE
use dazaar-payment

### DIFF
--- a/bin/fetch.js
+++ b/bin/fetch.js
@@ -78,6 +78,10 @@ buyer.ready(function (err) {
     })
   }
 
+  buyer.on('invalid', function (err) {
+    console.error('Payment invalid: ' + err.message)
+  })
+
   swarm(buyer).once('connection', function (_, info) {
     if (!argv.tail) return
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Marketplace for selling and buying hypercores",
   "main": "market.js",
   "dependencies": {
-    "dazaar-eos-stream": "1.0.0",
+    "dazaar-payment": "bitfinexcom/dazaar-payment",
     "fd-lock": "^1.0.2",
     "hypercore": "^8.2.5",
     "hypercore-crypto": "^1.0.0",


### PR DESCRIPTION
Moves to use dazaar-payment which is an easy interface we can add a ton of providers two.
In the future we should move these to be "plugin" installable, so we don't have to ship with anything basically