### PR TITLE
receive hook is passed the replication stream as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Send a custom message to the buying peers you are connected to.
 #### `seller.receive(type, onmessage)`
 
 Setup a handler to be called when a buying peer sends a message of a specific type.
+`onmessage` is called with `message` which is the message the remote send and `stream`
+which represents the stream it was sent on. Use `stream.remotePublicKey` to get the remotes buyer key out.
 
 #### `const buyer = market.buy(sellerKey)`
 

--- a/market.js
+++ b/market.js
@@ -448,7 +448,7 @@ function registerUserMessage (self, stream) {
     encoding: 'json',
     onmessage (data) {
       const fn = self._receiving.get(data.name)
-      if (fn) fn(data.message)
+      if (fn) fn(data.message, stream)
     }
   })
 


### PR DESCRIPTION
makes it easy to authenticate the remote, which is needed for things like lightning