### PR TITLE
allow both validate and disabling of uniqueFeed option

### DIFF
--- a/market.js
+++ b/market.js
@@ -359,7 +359,6 @@ class Seller extends EventEmitter {
 
     this.feed = feed
     this.uniqueFeed = opts.uniqueFeed !== false
-    if (!this.uniqueFeed && opts.validate) throw new Error('Cannot set both uniqueFeed = false and validate')
     this.validate = opts.validate
     this.revalidate = opts.validateInterval || 1000
     this.info = null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dazaar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Marketplace for selling and buying hypercores",
   "main": "market.js",
   "dependencies": {


### PR DESCRIPTION
Allows you to set a validate to communicate free terms back to a buyer whilst disabling the uniqueFeed generation needed for paid feeds