### PR TITLE
usability: allow dazaar card as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,13 @@ Emitted when a remote peer has disconnected.
 
 An array of all remote connected peers.
 
-#### `const buyer = market.buy(sellerKey, [options])`
+#### `const buyer = market.buy(sellerKey|dazaarCard, [options])`
 
 Buy a hypercore by creating a buyer instance.
 It is expected that the remote seller can verify that you purchased
 the data through a third party some how.
+
+If a `sellerKey` is used, it must be a Buffer.
 
 Options include:
 

--- a/market.js
+++ b/market.js
@@ -129,6 +129,11 @@ class Market extends EventEmitter {
   }
 
   buy (seller, opts) {
+    // support for dazaar cards
+    if (!Buffer.isBuffer(seller)) {
+      seller = Buffer.from(seller.id, 'hex')
+    }
+
     return new Buyer(this, this._db, seller, opts)
   }
 }


### PR DESCRIPTION
when a user downloads a dazaar card, to set up their market data
stream they would have to do something like this:

```js
const dazaarCard = JSON.parse(readFileSync('./dazaarcard.json'))
const id = Buffer.from(dazaarCard.id, 'hex')
const buyer = market.buy(id, { sparse: true })
```

To make setup and start easier for developers, this PR allows the
user to pass a dazaar card directly into the buy method.