### PR TITLE
make feeds wait for discovery as well, similar to the normal replicator

### DIFF
--- a/swarm.js
+++ b/swarm.js
@@ -2,12 +2,32 @@ const network = require('hyperswarm')
 const pump = require('pump')
 const market = require('./')
 
+class Event {
+  constructor () {
+    this.triggered = false
+    this.fns = new Set()
+  }
+
+  on (fn) {
+    if (this.triggered) return fn()
+    this.fns.add(fn)
+  }
+
+  emit () {
+    this.triggered = true
+    for (const fn of this.fns) fn()
+  }
+}
+
 module.exports = swarm
 
 function swarm (m, onjoin, opts) {
-  if (!opts) opts = { announceLocalAddress: true }
+  if (!opts) opts = { announceLocalAddress: true, preferredPort: 49737 }
   if (m.destroyed) throw new Error('Seller or buyer destroyed')
   const swarm = network(opts)
+
+  const oneConnection = new Event()
+  const allConnections = new Event()
 
   swarm.on('connection', function (socket, info) {
     if (m.destroyed) return socket.destroy(new Error('Seller or buyer destroyed'))
@@ -22,8 +42,29 @@ function swarm (m, onjoin, opts) {
   const announce = market.isSeller(m)
   const lookup = !announce
 
-  m.ready(() => swarm.join(m.discoveryKey, { announce, lookup }, onjoin))
+  if (!announce) {
+    if (m.feed) onfeed()
+    m.on('feed', onfeed)
+  }
+
+  m.ready(() => {
+    swarm.join(m.discoveryKey, { announce, lookup }, onjoin)
+    swarm.flush(() => {
+      allConnections.emit()
+      oneConnection.emit()
+    })
+  })
+
   m._swarm = swarm
 
   return swarm
+
+  function onfeed () {
+    const feed = m.feed
+    if (!feed.timeouts) return
+    const { update, get } = feed.timeouts
+    if (update) feed.timeouts.update = (cb) => oneConnection.on(() => update(cb))
+    if (get) feed.timeouts.get = (cb) => allConnections.on(() => get(cb))
+    feed.once('peer-open', oneConnection.emit.bind(oneConnection))
+  }
 }


### PR DESCRIPTION
This makes the bought feed update when running in sparse mode so when the user does

```
feed.update({ ifAvailable: true }, cb)
```

It always update the latest block available in the network, even if discovery is running and waiting for connections