### PR TITLE
swarm free feeds when unique feed generation is disabled

### DIFF
--- a/market.js
+++ b/market.js
@@ -513,6 +513,15 @@ class Seller extends EventEmitter {
           done(null, self._keyPair)
         })
       },
+      ondiscoverykey (discoveryKey) {
+        if (self.uniqueFeed) return p.close(discoveryKey)
+        // is free!
+        getUniqueFeed(function (err, feed) {
+          if (err || !discoveryKey.equals(feed.discoveryKey) || !p.remoteVerified(feed.key)) return p.close(discoveryKey)
+          if (p.opened(feed.key)) return
+          feed.replicate(p, { live: true })
+        })
+      },
       onauthenticate (remotePublicKey, done) {
         done()
       },
@@ -560,7 +569,7 @@ class Seller extends EventEmitter {
             if (!uniqueFeed) {
               uniqueFeed = feed
               oneTimeFeed.send(feed.key)
-              uniqueFeed.replicate(p, { live: true })
+              if (!p.opened(uniqueFeed.key)) uniqueFeed.replicate(p, { live: true })
             }
             setUploading(null, info)
           })

--- a/swarm.js
+++ b/swarm.js
@@ -22,7 +22,10 @@ function swarm (m, onjoin, opts) {
   const announce = market.isSeller(m)
   const lookup = !announce
 
-  m.ready(() => swarm.join(m.discoveryKey, { announce, lookup }, onjoin))
+  m.ready(() => {
+    if (announce && !m.uniqueFeed) swarm.join(m.feed.discoveryKey, { announce, lookup })
+    swarm.join(m.discoveryKey, { announce, lookup }, onjoin)
+  })
   m._swarm = swarm
 
   return swarm

--- a/swarm.js
+++ b/swarm.js
@@ -23,7 +23,7 @@ function swarm (m, onjoin, opts) {
   const lookup = !announce
 
   m.ready(() => {
-    if (announce && !m.uniqueFeed) swarm.join(m.feed.discoveryKey, { announce, lookup })
+    if (announce && m.uniqueFeed === false) swarm.join(m.feed.discoveryKey, { announce, lookup })
     swarm.join(m.discoveryKey, { announce, lookup }, onjoin)
   })
   m._swarm = swarm


### PR DESCRIPTION
This small change, makes any dazaar feed that is free and has uniqueFeed generation disabled will swarm like normal hypercores as well, which makes it scale very nicely :)